### PR TITLE
NHMA-35 - Automatic "access" attribute calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+CI Build status: [![Build status](https://ci.appveyor.com/api/projects/status/5voaaboe7wdv5eao/branch/master?svg=true)](https://ci.appveyor.com/project/Toshik/nhibernate-mapping-attributes/branch/master)
+
 ======================================
 What is NHibernate.Mapping.Attributes?
 ======================================

--- a/src/Generator/HbmWriterGenerator.cs
+++ b/src/Generator/HbmWriterGenerator.cs
@@ -117,6 +117,23 @@ namespace NHibernate.Mapping.Attributes.Generator
 				}
 			}"));
 						}
+                        else if (attribName == "access")
+                        {
+							method.Body.Add(Refly.CodeDom.Stm.Snippet(@"else
+            {
+                var access = string.Empty;
+                switch (member.MemberType)
+                {
+                    case MemberTypes.Property:
+                        access = ""property"";
+                        break;
+                    case MemberTypes.Field:
+                        access = ""field"";
+                        break;
+                }
+                writer.WriteAttributeString(""access"", access);
+            }"));
+                        }
 					}
 				}
 

--- a/src/Generator/HbmWriterGenerator.cs
+++ b/src/Generator/HbmWriterGenerator.cs
@@ -117,13 +117,14 @@ namespace NHibernate.Mapping.Attributes.Generator
 				}
 			}"));
 						}
-                        else if (attribName == "access" && schemaEltName != "Component") // "access" attribute auto calculation, except Component elements
+                        else if (attribName == "access" &&  !schemaEltIsRoot) // auto generate "access" attribute
                         {
 							method.Body.Add(Refly.CodeDom.Stm.Snippet(@"else
             {
                 var access = string.Empty;
                 switch (member.MemberType)
                 {
+
                     case MemberTypes.Property:
                         access = ""property"";
                         break;
@@ -132,6 +133,13 @@ namespace NHibernate.Mapping.Attributes.Generator
                         break;
                 }
                 writer.WriteAttributeString(""access"", access);
+            }"));
+                        }
+                        else if (attribName == "name" && !schemaEltIsRoot) // auto generate "name" attribute
+                        {
+                            method.Body.Add(Refly.CodeDom.Stm.Snippet(@"else
+            {
+                writer.WriteAttributeString(""name"", member.Name);
             }"));
                         }
 					}

--- a/src/Generator/HbmWriterGenerator.cs
+++ b/src/Generator/HbmWriterGenerator.cs
@@ -117,7 +117,7 @@ namespace NHibernate.Mapping.Attributes.Generator
 				}
 			}"));
 						}
-                        else if (attribName == "access")
+                        else if (attribName == "access" && schemaEltName != "Component") // "access" attribute auto calculation, except Component elements
                         {
 							method.Body.Add(Refly.CodeDom.Stm.Snippet(@"else
             {

--- a/src/Generator/Program.cs
+++ b/src/Generator/Program.cs
@@ -243,6 +243,7 @@ namespace NHibernate.Mapping.Attributes.Generator
 
 				Refly.CodeDom.NamespaceDeclaration nd = new Refly.CodeDom.NamespaceDeclaration("NHibernate.Mapping.Attributes", conformer);
 				nd.Imports.Clear(); // remove "using System;"
+                nd.Imports.Add("System.Reflection");
 				conformer.Capitalize = true;
 				Refly.CodeDom.ClassDeclaration hbmWriter = nd.AddClass("HbmWriter");
 				hbmWriter.Attributes = System.Reflection.TypeAttributes.Public;

--- a/src/NHibernate.Mapping.Attributes.Test/NHibernate.Mapping.Attributes.Test.csproj
+++ b/src/NHibernate.Mapping.Attributes.Test/NHibernate.Mapping.Attributes.Test.csproj
@@ -94,11 +94,11 @@
   <ItemGroup>
     <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
+      <HintPath>..\..\lib\net\4.0\log4net.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+      <HintPath>..\..\lib\net\4.0\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System">
       <Name>System</Name>


### PR DESCRIPTION
Usually you should specify "access" attribute.
There are mapping errors when someone refactors code and converts field to/from property and forgets to change attribute value.

There is some automatisation:
1. If you specify "access" explicit - it will be used
2. If "access" is not specified - NHMA will determine if it is "field" or "property"

It works for all attribute types except ComponentAttribute, there you should specify "access" manually.